### PR TITLE
UniFi 3.2.10 running on pfSense 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ To start and stop the controller, use the `service` command from the command lin
 - To start the controller:
 
   ```
-    service unifi start
+    service unifi.sh start
   ```
   The UniFi controller takes a few minutes to start. The 'start' command exits immediately while the startup continues in the background.
 
 - To stop the controller:
 
   ```
-    service unifi stop
+    service unifi.sh stop
   ```
   The the stop command takes a while to execute, and then the shutdown continues for several minutes in the background. The rc script will wait until the command received and the shutdown is finished. The idea is to hold up system shutdown until the UniFi controller has a chance to exit cleanly.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Challenges
 
 - Because the UniFi Controller software is proprietary, it cannot be built from source and cannot be included directly in a package. To work around this, we can download the UniFi controller software directly from Ubiquiti during the installation process.
 - Because Ubiquiti does not provide a standard way to fetch the software (not even a "latest" symlink), we cannot identify the appropriate version to download from Ubiquiti programmatically. It will be up to the package maintainer to keep the package up to date with the latest version of the software available from Ubiquiti.
-- Version 3 of the UniFI software has just been released, and it is not clear what the differences are from v2 for the purposes of this project.
 
 Licensing
 ---------
@@ -47,6 +46,12 @@ This project itself is licensed according to the two-clause BSD license.
 The UniFi Controller software is licensed as-is with no warranty, according to the README included with the software.
 
 [Ubiquiti has indicated via email](https://github.com/gozoinks/unifi-pfsense/wiki/Tacit-Approval) that acceptance of the EULA on the web site is not required before downloading the software.
+
+Requirements
+------------
+- This version of the script is currently only tested and working on a clean pfSense 2.2.
+- Be sure you have enough drive space available. UniFi software relies on MongoDB. In my test environment, it requires ~3.5GB available.
+- You can't run this on a NanoBSD pfSense. Don't try to hack this onto a NanoBSD pfSense distribution and destroy your flash in a few days or weeks.
 
 Installation
 ------------
@@ -81,8 +86,16 @@ To start and stop the controller, use the `service` command from the command lin
   ```
   The the stop command takes a while to execute, and then the shutdown continues for several minutes in the background. The rc script will wait until the command received and the shutdown is finished. The idea is to hold up system shutdown until the UniFi controller has a chance to exit cleanly.
 
+Known Issues / Caveats  
+----------------------
+- If you restore a backup through the UniFi web interface, it will restore the backup, stop the unifi services and not start them. You'll have to manually start the services again, or you can reboot pfSense through the pfSense admin portal.
+- This script has not been extensively tested when installing on "unclean" pfSense systems, eg, pfSense installations that have been customized with any additional packages.
+- Be Careful. Be sure you have full backup of your pfSense system and your UniFi controller (if not a new install). While we tried to make installation script safe, anything is possible. 
+
+
 References
 ----------
+
 
 These sources of information immediately come to mind:
 
@@ -90,3 +103,4 @@ These sources of information immediately come to mind:
 - [UniFI download and documentation](http://www.ubnt.com/download#UniFi:AP)
 - [UniFi updates blog](http://community.ubnt.com/t5/UniFi-Updates-Blog/bg-p/Blog_UniFi)
 - [pfSense: Developing Packages](https://doc.pfsense.org/index.php/Developing_Packages)
+

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -52,8 +52,6 @@ if [ "$OS_VERSION" != "2.2-RELEASE" ]; then
   exit 1
 fi
 
-
-
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:
 if [ -f /usr/local/etc/rc.d/unifi.sh ]; then
@@ -125,16 +123,6 @@ pkg_install "openjdk8"
 pkg_install "unzip"
 echo "Done installing required packages."
 
-# Fixing mongodb so that it runs on pfSense 2.2
-# 2015-03-15 -- this is required today and it could break in the future?
-echo -n "Fixing mongodb startup script and enabling mongodb service..."
-mv /usr/local/etc/rc.d/mongod /usr/local/etc/rc.d/mongod.sh
-if [ ! -f /etc/rc.conf.local ] || [ $(grep -c mongod /etc/rc.conf.local) -eq 0 ]; then
-  echo "mongod_enable=YES" >> /etc/rc.conf.local
-fi
-echo "done."
-
-
 # Switch to a temp directory for the Unifi download:
 cd `mktemp -d -t unifi`
 
@@ -189,6 +177,5 @@ fi
 
 # Start it up:
 echo -n "Starting the unifi service..."
-# /usr/local/etc/rc.d/mongod.sh start
-# /usr/local/etc/rc.d/unifi.sh start
+/usr/local/etc/rc.d/unifi.sh start
 echo " done."

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -163,6 +163,6 @@ fi
 
 # Start it up:
 echo -n "Starting the unifi service..."
-/usr/local/etc/rc.d/unifi.sh start
+service unifi.sh start
 echo " done."
 

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -9,17 +9,6 @@ UNIFI_SOFTWARE_URL="http://www.ubnt.com/downloads/unifi/3.2.10/UniFi.unix.zip"
 RC_SCRIPT_URL="https://raw.githubusercontent.com/kohenkatz/unifi-pfsense/pfsense-2.2/rc.d/unifi"
 PFSENSE_VERSION_SUPPORTED="2.2-RELEASE"
 
-# TODO: 
-# A lot more work needs to happen here:
-# * pfSense 2.2 has changed the behavior of startup scripts completely.
-#   - Using /usr/local/etc/rc.d for any startup scripts doesn't work because you can't rely on /etc/rc.conf
-#   - This also breaks the default installation of the mongodb package.
-
-# Testing "upgrade" process/procedure.
-#   - Because I've not been able to test auto-upgrading, I almost want to rip out all upgrade-related tasks,
-#     and instead give the user a way to rm old installation, forcing them to backup their own data and restore it
-#     after we install (basically, new install).
-
 # ----- FUNCTIONS HERE ---- 
 
 # attempts to install package command. if it can't a missing package it will bail out.
@@ -177,3 +166,4 @@ fi
 echo -n "Starting the unifi service..."
 /usr/local/etc/rc.d/unifi.sh start
 echo " done."
+

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -6,7 +6,7 @@
 # Note: I've set these as of 2015-03-07.
 # __PLEASE FIX RC_SCRIPT_URL WHEN YOU MERGE THIS PR__
 UNIFI_SOFTWARE_URL="http://www.ubnt.com/downloads/unifi/3.2.10/UniFi.unix.zip"
-RC_SCRIPT_URL="https://raw.githubusercontent.com/kohenkatz/unifi-pfsense/pfsense-2.2/rc.d/unifi"
+RC_SCRIPT_URL="https://raw.githubusercontent.com/gcohen55/unifi-pfsense/unifi-latest_3210/rc.d/unifi.sh"
 PFSENSE_VERSION_SUPPORTED="2.2-RELEASE"
 
 # ----- FUNCTIONS HERE ---- 

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -108,7 +108,7 @@ fi
 # Install mongodb, OpenJDK 8, and unzip (required to unpack Ubiquiti's download):
 echo "Installing required packages..."
 pkg_install "mongodb"
-pkg_install "openjdk8"
+pkg_install "openjdk"
 pkg_install "unzip"
 echo "Done installing required packages."
 

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,6 +4,7 @@
 
 # CONFIG OPTIONS
 # Note: I've set these as of 2015-03-07.
+# __PLEASE FIX RC_SCRIPT_URL WHEN YOU MERGE THIS PR__
 UNIFI_SOFTWARE_URL="http://www.ubnt.com/downloads/unifi/3.2.10/UniFi.unix.zip"
 RC_SCRIPT_URL="https://raw.githubusercontent.com/kohenkatz/unifi-pfsense/pfsense-2.2/rc.d/unifi"
 PFSENSE_VERSION_SUPPORTED="2.2-RELEASE"
@@ -155,8 +156,6 @@ echo -n "Installing rc script..."
 /usr/bin/fetch -o /usr/local/etc/rc.d/unifi.sh $RC_SCRIPT_URL
 echo " done."
 
-
-
 # Fix permissions so it'll run
 chmod +x /usr/local/etc/rc.d/unifi.sh
 
@@ -166,7 +165,6 @@ if [ ! -f /etc/rc.conf.local ] || [ $(grep -c unifi_enable /etc/rc.conf.local) -
   echo ""
   echo " done."
 fi
-
 
 # Restore the backup:
 if [ ! -z "$backupfile" ] && [ -f $backupfile ]; then

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -34,7 +34,7 @@ pkg_install()
 
 # ----- MAIN SCRIPT BEGINS ----
 
-# Let's be sure that we're running on pfSense 2.2.
+# Let's be sure that we're running on pfSense 2.2:
 echo -n "Checking that we're running on pfSense version $PFSENSE_VERSION_SUPPORTED..."
 OS_VERSION=$(cat /etc/version)
 if [ "$OS_VERSION" != "2.2-RELEASE" ]; then
@@ -71,7 +71,7 @@ if [ -d /usr/local/UniFi/data ]; then
   /usr/bin/tar -vczf $backupfile /usr/local/UniFi/data
 fi
 
-# Add the fstab entries apparently required for OpenJDKse:
+# Add the fstab entries apparently required for OpenJDK:
 if [ $(grep -c fdesc /etc/fstab) -eq 0 ]; then
   echo -n "Adding fdesc filesystem to /etc/fstab..."
   echo -e "fdesc\t\t\t/dev/fd\t\tfdescfs\trw\t\t0\t0" >> /etc/fstab
@@ -90,7 +90,7 @@ echo -n "Mounting new filesystems..."
 echo " done."
 
 
-# Check of the pkg manager is installed if not, install it.
+# Check of the pkg manager is installed if not, install it:
 if ! pkg -N 2> /dev/null; then
   echo -n "FreeBSD pkgng not installed. Installing..."
   env ASSUME_ALWAYS_YES=YES pkg bootstrap
@@ -98,15 +98,14 @@ if ! pkg -N 2> /dev/null; then
 fi
 
 
-# at this point, pkg should be installed. if it's not, we should probably quit.
+# at this point, pkg should be installed. if it's not, we should probably quit:
 if ! pkg -N 2> /dev/null; then
   echo "ERROR: pkgng installation failed. Exiting."
   exit 1
 fi
 
 
-# Install mongodb, OpenJDK 7, and unzip (required to unpack Ubiquiti's download):
-# -F skips a package if it's already installed, without throwing an error.
+# Install mongodb, OpenJDK 8, and unzip (required to unpack Ubiquiti's download):
 echo "Installing required packages..."
 pkg_install "mongodb"
 pkg_install "openjdk8"
@@ -145,7 +144,7 @@ echo -n "Installing rc script..."
 /usr/bin/fetch -o /usr/local/etc/rc.d/unifi.sh $RC_SCRIPT_URL
 echo " done."
 
-# Fix permissions so it'll run
+# Fix permissions so it'll run:
 chmod +x /usr/local/etc/rc.d/unifi.sh
 
 if [ ! -f /etc/rc.conf.local ] || [ $(grep -c unifi_enable /etc/rc.conf.local) -eq 0 ]; then

--- a/rc.d/unifi
+++ b/rc.d/unifi
@@ -7,7 +7,7 @@
 . /etc/rc.subr
 
 name="unifi"
-rcvar=`set_rcvar`
+rcvar="unifi_enable"
 start_cmd="unifi_start"
 stop_cmd="unifi_stop"
 

--- a/rc.d/unifi.sh
+++ b/rc.d/unifi.sh
@@ -13,7 +13,7 @@ stop_cmd="unifi_stop"
 
 pidfile="/var/run/${name}.pid"
 
-load_rc_config $name
+load_rc_config name
 
 unifi_start()
 {

--- a/rc.d/unifi.sh
+++ b/rc.d/unifi.sh
@@ -20,6 +20,12 @@ unifi_start()
   if checkyesno ${rcvar}; then
     echo "Starting UniFi controller. "
 
+    # since unifi in 3.2.10 does this whole try to connect locally on port 8080 and takes like 
+    # 10 minutes to do this
+    # this will open up netcat to listen on port 8080, and then close the connection immediately, then quit.
+    # leaving 8080 open for the actual service.
+    echo "" | nc -l 127.0.0.1 8080 >/dev/null &
+
     # The process will run until it is terminated and does not fork on its own.
     # So we start it in the background and stash the pid:
     /usr/local/bin/java -jar /usr/local/UniFi/lib/ace.jar start &


### PR DESCRIPTION
* pfSense 2.2 has changed the behavior of startup scripts completely.
  - Using /usr/local/etc/rc.d for any startup scripts doesn't work because you can't rely on /etc/rc.conf but you can, apparently, use /etc/rc.conf.local. I'm doing some more testing to see how this works.
  - UPDATE: It looks like it's working fine. I've an install on a clean pfSense testbed that I built out in a VM.


* Testing "upgrade/reinstall" backup/restore
  - Because I've not been able to test auto-upgrading, I almost want to rip out all upgrade-related tasks, and instead give the user a way to rm old installation, forcing them to backup their own data and restore it after we install (basically, new install).
  - I'm not package maintainer, so that's not my decision. I'm only bringing up the idea because I'm a scaredy cat.

  - Also, from readme (packed in UniFi unix zip file)
```
		* How do I backup / restore?
		  1. Make sure UniFi is not running
		  2. for backup, tar/zip everything inside /path/to/UniFi/data
		     for restore, untar/unzip everything back to /path/to/UniFi/data
		  3. restart UniFi

		* How do I upgrade?
		  1. make a backup
		  2. download the new UniFi-linux.zip and re-install
		  3. untar/unzip the backup file back
```
----

Thanks to:
	- gozoinks for creating the original script.
	- kohenkatz for the fixed rc pfSense 2.2 script and some other snippets from install-unifi.sh
	- UniFi for making such a great product
	- pfSense Team for being generally awesome.
