### PR TITLE
Use SSL for packages and the install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To install the controller software and the rc script:
 2. Run this one-line command, which downloads the install script from Github and executes it with sh (points to current 4.6.6 branch):
 
   ```
-    fetch -o - http://git.io/j7Jy | sh -s
+    fetch -o - https://git.io/j7Jy | sh -s
   ```
 
 The install script will install dependencies, download the UniFi controller software, make some adjustments, and start the UniFi controller.

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -13,7 +13,7 @@ UNIFI_SOFTWARE_URL="https://dl.ubnt.com/unifi/5.3.8/UniFi.unix.zip"
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"
 
 #FreeBSD package source:
-FREEBSD_PACKAGE_URL="http://pkg.freebsd.org/freebsd:10:x86:${OS_ARCH}/latest/All/"
+FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/freebsd:10:x86:${OS_ARCH}/latest/All/"
 
 # If pkg-ng is not yet installed, bootstrap it:
 if ! /usr/sbin/pkg -N 2> /dev/null; then
@@ -142,7 +142,7 @@ echo " done."
 
 # Replace snappy java library to support AP adoption with latest firmware
 echo -n "Updating snappy java..."
-fetch http://pkg.freebsd.org/freebsd:10:x86:${OS_ARCH}/latest/All/snappyjava-1.0.4.1_2.txz
+fetch https://pkg.freebsd.org/freebsd:10:x86:${OS_ARCH}/latest/All/snappyjava-1.0.4.1_2.txz
 tar vfx snappyjava-1.0.4.1_2.txz
 mv /usr/local/UniFi/lib/snappy-java-1.0.5.jar /usr/local/UniFi/lib/snappy-java-1.0.5.jar.backup
 cp ./usr/local/share/java/classes/snappy-java.jar /usr/local/UniFi/lib/snappy-java-1.0.5.jar


### PR DESCRIPTION
I know it adds a little extra overhead but it really adds peace of mind to use SSL whenever possible - especially when you're running everything as root.