### PR TITLE
Ensure backup is restored to the correct path

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -204,7 +204,7 @@ fi
 if [ ! -z "${BACKUPFILE}" ] && [ -f ${BACKUPFILE} ]; then
   echo "Restoring UniFi data..."
   mv /usr/local/UniFi/data /usr/local/UniFi/data-orig
-  /usr/bin/tar -vxzf ${BACKUPFILE}
+  /usr/bin/tar -vxzf ${BACKUPFILE} -C /
 fi
 
 # Start it up:


### PR DESCRIPTION
Since tar ignores the leading slash during compression, this change will make sure that the backup is restored to `/usr` instead of `./usr`. This keeps the restore process from failing if you run the script from anywhere other than `/`.