### PR TITLE
Spoof snappyjava version for UniFi 5.5.x

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -7,7 +7,7 @@
 OS_ARCH=`getconf LONG_BIT`
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ubnt.com/unifi/5.4.11/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ubnt.com/unifi/5.4.14/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"


### PR DESCRIPTION
copy installed snappyjava file & rename to acomodate Unifi controller 5.5.x req


fetch http://pkg.freebsd.org/freebsd:11:x86:64/latest/All/snappyjava-${snappyjavavers}.txz
tar vfx snappyjava-${snappyjavavers}.txz
cp ./usr/local/share/java/classes/snappy-java.jar /usr/local/UniFi/lib/snappy-java-1.1.2.6.jar
