### PR TITLE
Add support for pfSense 2.4

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -3,20 +3,11 @@
 # install-unifi.sh
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
-# OS architecture
-OS_ARCH=`getconf LONG_BIT`
-
 # The latest version of UniFi:
 UNIFI_SOFTWARE_URL="https://dl.ubnt.com/unifi/5.5.19/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"
-
-#FreeBSD package source:
-FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/freebsd:10:x86:${OS_ARCH}/latest/All/"
-
-#FreeBSD package list:
-FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/freebsd:10:x86:${OS_ARCH}/latest/packagesite.txz"
 
 
 # If pkg-ng is not yet installed, bootstrap it:
@@ -31,6 +22,15 @@ if ! /usr/sbin/pkg -N 2> /dev/null; then
   echo "ERROR: pkgng installation failed. Exiting."
   exit 1
 fi
+
+# Determine this installation's Application Binary Interface
+ABI=`/usr/sbin/pkg config abi`
+
+# FreeBSD package source:
+FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
+
+# FreeBSD package list:
+FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:


### PR DESCRIPTION
Since pfSense 2.4 is now based on FreeBSD 11, we needed a new, more generic method to generate the ABI used in the repository URLs - one that will work with pfSense 2.2 through 2.4 and hopefully beyond.

I switched to using the `pkg config abi` command to produce the full ABI for us instead of manually formatting the string ourselves. The advantage of this method is that it will support whatever version of FreeBSD that pfSense happens to be using - such as 10, 11, 12, and the ARM/MIPS builds.
I haven't actually tested if UniFi runs on ARM or MIPS, however.

This could theoretically resolve #57.
Let me know if you have any suggestions and I'll be happy to update my PR.