### PR TITLE
Change data directory mv name

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -204,7 +204,7 @@ fi
 # Restore the backup:
 if [ ! -z "${BACKUPFILE}" ] && [ -f ${BACKUPFILE} ]; then
   echo "Restoring UniFi data..."
-  mv /usr/local/UniFi/data /usr/local/UniFi/data-orig
+  mv /usr/local/UniFi/data /usr/local/UniFi/data-`date +%Y%m%d-%H%M`
   /usr/bin/tar -vxzf ${BACKUPFILE} -C /
 fi
 


### PR DESCRIPTION
When using this script to update for the third time without removing any of the previous data directories, you will end up with an error and the current data directory will not be moved.

1st upgrade, data is moved to data-orig successfully.

2nd upgrade, data is moved to data-orig/data

3rd upgrade, the move command tries to move data to data-orig/data, which already exists and is a directory. Results in an error.

This will move data to data-'timestamp' which will prevent such collisions unless you run the upgrade 3 times in the span of a minute (highly unlikely)