### PR TITLE
Update to 5.9.29 UniFi Controller for Unix

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -97,16 +97,25 @@ AddPkg () {
 }
 
 AddPkg snappy
+AddPkg cyrus-sasl
+AddPkg xorgproto
+AddPkg libXau
+AddPkg libICE
+AddPkg libX11
+AddPkg libfontenc
+AddPkg mkfontscale
+AddPkg mkfontdir
+AddPkg dejavu
 AddPkg python2
 AddPkg v8
-AddPkg mongodb
+AddPkg icu
+AddPkg boost-libs
+AddPkg mongodb34
 AddPkg unzip
 AddPkg pcre
 AddPkg alsa-lib
 AddPkg freetype2
 AddPkg fontconfig
-AddPkg xproto
-AddPkg kbproto
 AddPkg libXdmcp
 AddPkg libpthread-stubs
 AddPkg libXau
@@ -114,9 +123,6 @@ AddPkg libxcb
 AddPkg libICE
 AddPkg libSM
 AddPkg java-zoneinfo
-AddPkg fixesproto
-AddPkg xextproto
-AddPkg inputproto
 AddPkg libX11
 AddPkg libXfixes
 AddPkg libXext
@@ -126,9 +132,7 @@ AddPkg libfontenc
 AddPkg mkfontscale
 AddPkg mkfontdir
 AddPkg dejavu
-AddPkg recordproto
 AddPkg libXtst
-AddPkg renderproto
 AddPkg libXrender
 AddPkg javavmwrapper
 AddPkg giflib

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -212,3 +212,4 @@ fi
 echo -n "Starting the unifi service..."
 /usr/sbin/service unifi.sh start
 echo " done."
+

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/5.7.20/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/5.9.29/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -97,7 +97,7 @@ AddPkg () {
 }
 
 AddPkg openjdk8
-AddPkg mongodb34
+AddPkg mongodb
 AddPkg renderproto
 AddPkg recordproto
 AddPkg fixesproto

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -110,7 +110,7 @@ AddPkg python2
 AddPkg v8
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb
+AddPkg mongodb34
 AddPkg unzip
 AddPkg pcre
 AddPkg alsa-lib
@@ -212,4 +212,3 @@ fi
 echo -n "Starting the unifi service..."
 /usr/sbin/service unifi.sh start
 echo " done."
-

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -96,6 +96,15 @@ AddPkg () {
 	env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f ${FREEBSD_PACKAGE_URL}${pkgname}-${pkgvers}.txz
 }
 
+AddPkg openjdk8
+AddPkg mongodb34
+AddPkg renderproto
+AddPkg recordproto
+AddPkg fixesproto
+AddPkg xextproto
+AddPkg inputproto
+AddPkg xproto
+AddPkg kbproto
 AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg xorgproto
@@ -110,7 +119,6 @@ AddPkg python2
 AddPkg v8
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb34
 AddPkg unzip
 AddPkg pcre
 AddPkg alsa-lib
@@ -136,7 +144,6 @@ AddPkg libXtst
 AddPkg libXrender
 AddPkg javavmwrapper
 AddPkg giflib
-AddPkg openjdk8
 AddPkg snappyjava
 
 # Clean up downloaded package manifest:

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -110,7 +110,7 @@ AddPkg python2
 AddPkg v8
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb34
+AddPkg mongodb
 AddPkg unzip
 AddPkg pcre
 AddPkg alsa-lib


### PR DESCRIPTION
Note: UniFi Controller for Unix currently requires MongoDB 3.4.x or 3.5.x... will not work 3.6.x

Reference: https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-SDN-Controller-5-9-29-Stable-has-been-released/ba-p/2516852