### PR TITLE
Add automatic version checking

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -6,16 +6,23 @@
 # Either use provided version or get latest from API
 UNIFI_VERSION=$1
 if [ -z "$UNIFI_VERSION" ]; then
-    echo "Version not supplied, fetching latest"
-    UNIFI_VERSION=$(
-        curl -sL 'https://www.ui.com/download/?platform=unifi' -H 'X-Requested-With: XMLHttpRequest' |
-        jq -r '.downloads | map(select(.slug | test("unifi-network-controller-.*"))) | sort_by(.date_published) | .[-1].version'
-    )
-    printf "Is version $UNIFI_VERSION okay? [y/N] " && read RESPONSE  
-    case $RESPONSE in
-        [Yy] ) ;;                    
-        * ) exit 1;;                   
-    esac
+  echo "Version not supplied, fetching latest"
+  UNIFI_VERSION=$(
+    curl -sL 'https://www.ui.com/download/?platform=unifi' -H 'X-Requested-With: XMLHttpRequest' |
+    jq -r '.downloads | map(select(.slug | test("unifi-network-controller-.*"))) | sort_by(.date_published) | .[-1].version' 2>/dev/null
+  )
+
+  if ! $(echo "$UNIFI_VERSION" | egrep -q '^[0-9]+\.[0-9]+\.[0-9]+$'); then
+    echo "Version \"$UNIFI_VERSION\" doesn't make sense" 
+    echo "If that's correct, run this again with it as the first argument"
+    exit 1
+  fi  
+
+  printf "Is version $UNIFI_VERSION okay? [y/N] " && read RESPONSE  
+  case $RESPONSE in
+    [Yy] ) ;;                    
+    * ) exit 1;;                   
+  esac
 fi
 echo "Installing UniFi Controller $UNIFI_VERSION"
 

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -3,8 +3,24 @@
 # install-unifi.sh
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
+# Either use provided version or get latest from API
+UNIFI_VERSION=$1
+if [ -z "$UNIFI_VERSION" ]; then
+    echo "Version not supplied, fetching latest"
+    UNIFI_VERSION=$(
+        curl -sL 'https://www.ui.com/download/?platform=unifi' -H 'X-Requested-With: XMLHttpRequest' |
+        jq -r '.downloads | map(select(.slug | test("unifi-network-controller-.*"))) | sort_by(.date_published) | .[-1].version'
+    )
+    printf "Is version $UNIFI_VERSION okay? [y/N] " && read RESPONSE  
+    case $RESPONSE in
+        [Yy] ) ;;                    
+        * ) exit 1;;                   
+    esac
+fi
+echo "Installing UniFi Controller $UNIFI_VERSION"
+
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/5.10.20/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/$UNIFI_VERSION/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"


### PR DESCRIPTION
This is more of a base to work off of. Unfortunately adds dependency on `jq` and `curl`. I don't know FreeBSD or pfSense, but I noticed `fetch` was used to download the file. Maybe that could replace `curl`? Some other changes will need to be made, because you can no longer assume the version is valid.