### PR TITLE
Update to mongodb36

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -114,7 +114,7 @@ AddPkg python2
 AddPkg v8
 AddPkg icu
 AddPkg boost-libs
-AddPkg mongodb34
+AddPkg mongodb36
 AddPkg unzip
 AddPkg pcre
 AddPkg alsa-lib


### PR DESCRIPTION
Mongo34 is deprecated and no longer in the package list.