### PR TITLE
Update install-unifi.sh

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/5.14.23/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/6.0.22/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"


### PR DESCRIPTION
bumps to Unifi version 6.0.23

no problems encountered, dashboard seem functional, after install new firmware for your Unifi devices will be detected. probably a patch for the 6.0 unifi issues, perhaps.

tested on the following(i have meshing)
OPNsense 20.7.2-amd64
FreeBSD 12.1-RELEASE-p8-HBSD

server1
(1 switch us16 150w, 1 switch us24 250w, 4 AC LR, 2 AC pro)

server2
(1 switch us8, 1 switch us8 60w, 2 AC LR, 4 AC pro)