### PR TITLE
Bumps version to 6.0.28 Official Release

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -96,7 +96,6 @@ echo " done."
 # Install mongodb, OpenJDK, and unzip (required to unpack Ubiquiti's download):
 # -F skips a package if it's already installed, without throwing an error.
 echo "Installing required packages..."
-tar xv -C / -f /usr/local/share/pfSense/base.txz ./usr/bin/install
 #uncomment below for pfSense 2.2.x:
 #env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg install mongodb openjdk unzip pcre v8 snappy
 
@@ -121,11 +120,49 @@ AddPkg () {
 		fi
 }
 
+#Unlocks all Packages for install-unifi.sh (if an install was done previously)
+pkg unlock -yq png
+pkg unlock -yq freetype2
+pkg unlock -yq fontconfig
+pkg unlock -yq alsa-lib
+pkg unlock -yq python37
+pkg unlock -yq libfontenc
+pkg unlock -yq mkfontscale
+pkg unlock -yq dejavu
+pkg unlock -yq giflib
+pkg unlock -yq xorgproto
+pkg unlock -yq libXdmcp
+pkg unlock -yq libpthread-stubs
+pkg unlock -yq libXau
+pkg unlock -yq libxcb
+pkg unlock -yq libICE
+pkg unlock -yq libSM
+pkg unlock -yq libX11
+pkg unlock -yq libXfixes
+pkg unlock -yq libXext
+pkg unlock -yq libXi
+pkg unlock -yq libXt
+pkg unlock -yq libXtst
+pkg unlock -yq libXrender
+pkg unlock -yq libinotify
+pkg unlock -yq javavmwrapper
+pkg unlock -yq java-zoneinfo
+pkg unlock -yq openjdk8
+pkg unlock -yq snappyjava
+pkg unlock -yq snappy
+pkg unlock -yq cyrus-sasl
+pkg unlock -yq icu
+pkg unlock -yq boost-libs
+pkg unlock -yq mongodb36
+pkg unlock -yq unzip
+pkg unlock -yq pcre
+
+#Add the following Packages for installation or reinstallation (if something was removed)
 AddPkg png
 AddPkg freetype2
 AddPkg fontconfig
 AddPkg alsa-lib
-AddPkg python27
+AddPkg python37
 AddPkg libfontenc
 AddPkg mkfontscale
 AddPkg dejavu
@@ -151,12 +188,48 @@ AddPkg openjdk8
 AddPkg snappyjava
 AddPkg snappy
 AddPkg cyrus-sasl
-AddPkg v8
 AddPkg icu
 AddPkg boost-libs
 AddPkg mongodb36
 AddPkg unzip
 AddPkg pcre
+
+#Locks all Packages for install-unifi.sh following their install or reinstall (this prevents pkg upgrade to break the UniFi controller, or OPNSense Updates to do the same)
+pkg lock -yq png
+pkg lock -yq freetype2
+pkg lock -yq fontconfig
+pkg lock -yq alsa-lib
+pkg lock -yq python37
+pkg lock -yq libfontenc
+pkg lock -yq mkfontscale
+pkg lock -yq dejavu
+pkg lock -yq giflib
+pkg lock -yq xorgproto
+pkg lock -yq libXdmcp
+pkg lock -yq libpthread-stubs
+pkg lock -yq libXau
+pkg lock -yq libxcb
+pkg lock -yq libICE
+pkg lock -yq libSM
+pkg lock -yq libX11
+pkg lock -yq libXfixes
+pkg lock -yq libXext
+pkg lock -yq libXi
+pkg lock -yq libXt
+pkg lock -yq libXtst
+pkg lock -yq libXrender
+pkg lock -yq libinotify
+pkg lock -yq javavmwrapper
+pkg lock -yq java-zoneinfo
+pkg lock -yq openjdk8
+pkg lock -yq snappyjava
+pkg lock -yq snappy
+pkg lock -yq cyrus-sasl
+pkg lock -yq icu
+pkg lock -yq boost-libs
+pkg lock -yq mongodb36
+pkg lock -yq unzip
+pkg lock -yq pcre
 
 # Clean up downloaded package manifest:
 rm packagesite.*

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,11 +4,10 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/5.14.23/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.28/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"
-
 
 # If pkg-ng is not yet installed, bootstrap it:
 if ! /usr/sbin/pkg -N 2> /dev/null; then
@@ -122,41 +121,42 @@ AddPkg () {
 		fi
 }
 
-AddPkg snappy
-AddPkg cyrus-sasl
-AddPkg xorgproto
-AddPkg python37
-AddPkg v8
-AddPkg icu
-AddPkg boost-libs
-AddPkg mongodb36
-AddPkg unzip
-AddPkg pcre
-AddPkg alsa-lib
+AddPkg png
 AddPkg freetype2
 AddPkg fontconfig
+AddPkg alsa-lib
+AddPkg python27
+AddPkg libfontenc
+AddPkg mkfontscale
+AddPkg dejavu
+AddPkg giflib
+AddPkg xorgproto
 AddPkg libXdmcp
 AddPkg libpthread-stubs
 AddPkg libXau
 AddPkg libxcb
 AddPkg libICE
 AddPkg libSM
-AddPkg java-zoneinfo
 AddPkg libX11
 AddPkg libXfixes
 AddPkg libXext
 AddPkg libXi
 AddPkg libXt
-AddPkg libfontenc
-AddPkg mkfontscale
-AddPkg dejavu
 AddPkg libXtst
 AddPkg libXrender
 AddPkg libinotify
 AddPkg javavmwrapper
-AddPkg giflib
+AddPkg java-zoneinfo
 AddPkg openjdk8
 AddPkg snappyjava
+AddPkg snappy
+AddPkg cyrus-sasl
+AddPkg v8
+AddPkg icu
+AddPkg boost-libs
+AddPkg mongodb36
+AddPkg unzip
+AddPkg pcre
 
 # Clean up downloaded package manifest:
 rm packagesite.*


### PR DESCRIPTION
Bumps version to 6.0.28 Official Release, this is according to Ubiquiti a stable release.

Edit: Since I have deleted many different pulls of the 6.0.2x controller, due to incredibly fast releases by Ubiquiti, I must repeat that Python37 was replaced with Python27 due to V8 having a dependency for 27. Mongodb can also run on Python27, so this is to potentially declutter the script as well as not need an additional pkg installed. png was also added as it is a dependency for freetype2. Also the order of all of the packages was reordered to make sure dependencies are installed before their packages... 

Cannot downgrade from 6.1.x without a full uninstall of the UniFi controller... This did install clean on fresh virtual machines running on:

PFSense 2.4.5
FreeBSD 11.3-STABLE

OPNSense 20.7.3
FreeBSD 12.1-RELEASE

Link to Ubiquiti's forum about the release:

https://community.ui.com/releases/UniFi-Network-Controller-6-0-28/23c77a99-0957-449a-b3c0-58a37d4df81f

Install link:

fetch -o - https://git.io/JTD2a | sh -s

Install link with text output (If you do decide to install it, and feel like sharing your Bash results, please upload the text file)

fetch -o - https://git.io/JTD2a | sh -s cmd |& tee unifi6028.txt