### PR TITLE
Bumps version to 6.0.43 Official Release

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,11 +4,10 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="http://dl.ubnt.com/unifi/5.14.23/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.36/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"
-
 
 # If pkg-ng is not yet installed, bootstrap it:
 if ! /usr/sbin/pkg -N 2> /dev/null; then
@@ -97,7 +96,6 @@ echo " done."
 # Install mongodb, OpenJDK, and unzip (required to unpack Ubiquiti's download):
 # -F skips a package if it's already installed, without throwing an error.
 echo "Installing required packages..."
-tar xv -C / -f /usr/local/share/pfSense/base.txz ./usr/bin/install
 #uncomment below for pfSense 2.2.x:
 #env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg install mongodb openjdk unzip pcre v8 snappy
 
@@ -122,41 +120,116 @@ AddPkg () {
 		fi
 }
 
-AddPkg snappy
-AddPkg cyrus-sasl
-AddPkg xorgproto
-AddPkg python37
-AddPkg v8
-AddPkg icu
-AddPkg boost-libs
-AddPkg mongodb36
-AddPkg unzip
-AddPkg pcre
-AddPkg alsa-lib
+#Unlocks all Packages for install-unifi.sh (if an install was done previously)
+pkg unlock -yq png
+pkg unlock -yq freetype2
+pkg unlock -yq fontconfig
+pkg unlock -yq alsa-lib
+pkg unlock -yq python37
+pkg unlock -yq libfontenc
+pkg unlock -yq mkfontscale
+pkg unlock -yq dejavu
+pkg unlock -yq giflib
+pkg unlock -yq xorgproto
+pkg unlock -yq libXdmcp
+pkg unlock -yq libpthread-stubs
+pkg unlock -yq libXau
+pkg unlock -yq libxcb
+pkg unlock -yq libICE
+pkg unlock -yq libSM
+pkg unlock -yq libX11
+pkg unlock -yq libXfixes
+pkg unlock -yq libXext
+pkg unlock -yq libXi
+pkg unlock -yq libXt
+pkg unlock -yq libXtst
+pkg unlock -yq libXrender
+pkg unlock -yq libinotify
+pkg unlock -yq javavmwrapper
+pkg unlock -yq java-zoneinfo
+pkg unlock -yq openjdk8
+pkg unlock -yq snappyjava
+pkg unlock -yq snappy
+pkg unlock -yq cyrus-sasl
+pkg unlock -yq icu
+pkg unlock -yq boost-libs
+pkg unlock -yq mongodb36
+pkg unlock -yq unzip
+pkg unlock -yq pcre
+
+#Add the following Packages for installation or reinstallation (if something was removed)
+AddPkg png
 AddPkg freetype2
 AddPkg fontconfig
+AddPkg alsa-lib
+AddPkg python37
+AddPkg libfontenc
+AddPkg mkfontscale
+AddPkg dejavu
+AddPkg giflib
+AddPkg xorgproto
 AddPkg libXdmcp
 AddPkg libpthread-stubs
 AddPkg libXau
 AddPkg libxcb
 AddPkg libICE
 AddPkg libSM
-AddPkg java-zoneinfo
 AddPkg libX11
 AddPkg libXfixes
 AddPkg libXext
 AddPkg libXi
 AddPkg libXt
-AddPkg libfontenc
-AddPkg mkfontscale
-AddPkg dejavu
 AddPkg libXtst
 AddPkg libXrender
 AddPkg libinotify
 AddPkg javavmwrapper
-AddPkg giflib
+AddPkg java-zoneinfo
 AddPkg openjdk8
 AddPkg snappyjava
+AddPkg snappy
+AddPkg cyrus-sasl
+AddPkg icu
+AddPkg boost-libs
+AddPkg mongodb36
+AddPkg unzip
+AddPkg pcre
+
+#Locks all Packages for install-unifi.sh following their install or reinstall (this prevents pkg upgrade to break the UniFi controller, or OPNSense Updates to do the same)
+pkg lock -yq png
+pkg lock -yq freetype2
+pkg lock -yq fontconfig
+pkg lock -yq alsa-lib
+pkg lock -yq python37
+pkg lock -yq libfontenc
+pkg lock -yq mkfontscale
+pkg lock -yq dejavu
+pkg lock -yq giflib
+pkg lock -yq xorgproto
+pkg lock -yq libXdmcp
+pkg lock -yq libpthread-stubs
+pkg lock -yq libXau
+pkg lock -yq libxcb
+pkg lock -yq libICE
+pkg lock -yq libSM
+pkg lock -yq libX11
+pkg lock -yq libXfixes
+pkg lock -yq libXext
+pkg lock -yq libXi
+pkg lock -yq libXt
+pkg lock -yq libXtst
+pkg lock -yq libXrender
+pkg lock -yq libinotify
+pkg lock -yq javavmwrapper
+pkg lock -yq java-zoneinfo
+pkg lock -yq openjdk8
+pkg lock -yq snappyjava
+pkg lock -yq snappy
+pkg lock -yq cyrus-sasl
+pkg lock -yq icu
+pkg lock -yq boost-libs
+pkg lock -yq mongodb36
+pkg lock -yq unzip
+pkg lock -yq pcre
 
 # Clean up downloaded package manifest:
 rm packagesite.*

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.36/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.41/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.41/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.0.43-a8e04a273f/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/gozoinks/unifi-pfsense/master/rc.d/unifi.sh"

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -53,6 +53,9 @@ if [ $(ps ax | grep -c "/usr/local/UniFi/data/[d]b") -ne 0 ]; then
   echo " done."
 fi
 
+# Repairs Mongodb database in case of corruption
+mongod --dbpath /usr/local/UniFi/data/db --repair
+
 # If an installation exists, we'll need to back up configuration:
 if [ -d /usr/local/UniFi/data ]; then
   echo "Backing up UniFi data..."

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -104,58 +104,23 @@ tar vfx packagesite.txz
 
 AddPkg () {
  	pkgname=$1
+        pkg unlock -yq $pkgname
  	pkginfo=`grep "\"name\":\"$pkgname\"" packagesite.yaml`
  	pkgvers=`echo $pkginfo | pcregrep -o1 '"version":"(.*?)"' | head -1`
 
 	# compare version for update/install
  	if [ `pkg info | grep -c $pkgname-$pkgvers` -eq 1 ]; then
-			echo "Package $pkgname-$pkgvers already installed."
-		else
-			env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f ${FREEBSD_PACKAGE_URL}${pkgname}-${pkgvers}.txz
+	     echo "Package $pkgname-$pkgvers already installed."
+	else
+	     env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f ${FREEBSD_PACKAGE_URL}${pkgname}-${pkgvers}.txz
 
-			# if update openjdk8 then force detele snappyjava to reinstall for new version of openjdk
-			if [ "$pkgname" == "openjdk8" ]; then
-				env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete snappyjava
-			fi
-		fi
+	     # if update openjdk8 then force detele snappyjava to reinstall for new version of openjdk
+	     if [ "$pkgname" == "openjdk8" ]; then
+	          env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete snappyjava
+             fi
+        fi
+        pkg lock -yq $pkgname
 }
-
-#Unlocks all Packages for install-unifi.sh (if an install was done previously)
-pkg unlock -yq png
-pkg unlock -yq freetype2
-pkg unlock -yq fontconfig
-pkg unlock -yq alsa-lib
-pkg unlock -yq python37
-pkg unlock -yq libfontenc
-pkg unlock -yq mkfontscale
-pkg unlock -yq dejavu
-pkg unlock -yq giflib
-pkg unlock -yq xorgproto
-pkg unlock -yq libXdmcp
-pkg unlock -yq libpthread-stubs
-pkg unlock -yq libXau
-pkg unlock -yq libxcb
-pkg unlock -yq libICE
-pkg unlock -yq libSM
-pkg unlock -yq libX11
-pkg unlock -yq libXfixes
-pkg unlock -yq libXext
-pkg unlock -yq libXi
-pkg unlock -yq libXt
-pkg unlock -yq libXtst
-pkg unlock -yq libXrender
-pkg unlock -yq libinotify
-pkg unlock -yq javavmwrapper
-pkg unlock -yq java-zoneinfo
-pkg unlock -yq openjdk8
-pkg unlock -yq snappyjava
-pkg unlock -yq snappy
-pkg unlock -yq cyrus-sasl
-pkg unlock -yq icu
-pkg unlock -yq boost-libs
-pkg unlock -yq mongodb36
-pkg unlock -yq unzip
-pkg unlock -yq pcre
 
 #Add the following Packages for installation or reinstallation (if something was removed)
 AddPkg png
@@ -193,43 +158,6 @@ AddPkg boost-libs
 AddPkg mongodb36
 AddPkg unzip
 AddPkg pcre
-
-#Locks all Packages for install-unifi.sh following their install or reinstall (this prevents pkg upgrade to break the UniFi controller, or OPNSense Updates to do the same)
-pkg lock -yq png
-pkg lock -yq freetype2
-pkg lock -yq fontconfig
-pkg lock -yq alsa-lib
-pkg lock -yq python37
-pkg lock -yq libfontenc
-pkg lock -yq mkfontscale
-pkg lock -yq dejavu
-pkg lock -yq giflib
-pkg lock -yq xorgproto
-pkg lock -yq libXdmcp
-pkg lock -yq libpthread-stubs
-pkg lock -yq libXau
-pkg lock -yq libxcb
-pkg lock -yq libICE
-pkg lock -yq libSM
-pkg lock -yq libX11
-pkg lock -yq libXfixes
-pkg lock -yq libXext
-pkg lock -yq libXi
-pkg lock -yq libXt
-pkg lock -yq libXtst
-pkg lock -yq libXrender
-pkg lock -yq libinotify
-pkg lock -yq javavmwrapper
-pkg lock -yq java-zoneinfo
-pkg lock -yq openjdk8
-pkg lock -yq snappyjava
-pkg lock -yq snappy
-pkg lock -yq cyrus-sasl
-pkg lock -yq icu
-pkg lock -yq boost-libs
-pkg lock -yq mongodb36
-pkg lock -yq unzip
-pkg lock -yq pcre
 
 # Clean up downloaded package manifest:
 rm packagesite.*


### PR DESCRIPTION
Bumps version to 6.0.43 Official Release, this is according to Ubiquiti a stable release.
Edit: I just patched a few things. Found out by the V8 port being down on FreeBSD, that V8 is not necessary, so I went ahead and got rid of Python27 for Python37... I also got rid of line 99, which is currently line 100 of the commit, this line for the base.txz file is completely unnecessary and does not effect the installation of the controller. I added a unlock and lock of the packages that are installed by the install-unifi.sh script... This was done for situations where a user might be running something like OPNSense where updates from OPNSense like to reinstall packages which can effectively break the UniFi controller. This currently is the most stable script yet, of course all depedency errors were also fixed.
Added script unlock and lock package to AddPkg per @jmcphail , also added mongodb database repair per @thiscantbeserious
Cannot downgrade from 6.1.x without a full uninstall of the UniFi controller... This did install clean on fresh virtual machines running on:
PFSense 2.4.5
FreeBSD 11.3-STABLE
PFSense 2.5.0-DEVELOPMENT (amd64)
built on Tue Nov 17 13:00:44 EST 2020
FreeBSD 12.2-STABLE
OPNSense 20.7.3
FreeBSD 12.1-RELEASE
Link to Ubiquiti's forum about the release:
https://community.ui.com/releases/UniFi-Network-Controller-6-0-41/25633411-0273-4197-bf30-4aff30b3701e
Install link:
fetch -o - https://git.io/JLugq | sh -s
Install link with text output (If you do decide to install it, and feel like sharing your Bash results, please upload the text file)
fetch -o - https://git.io/JLugq | sh -s cmd |& tee unifi6043.txt
