### PR TITLE
Switch package extensions from .txz to .pkg

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -27,10 +27,10 @@ fi
 ABI=`/usr/sbin/pkg config abi`
 
 # FreeBSD package source:
-FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/All/"
+FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/"
 
 # FreeBSD package list:
-FREEBSD_PACKAGE_LIST_URL="https://pkg.freebsd.org/${ABI}/latest/packagesite.txz"
+FREEBSD_PACKAGE_LIST_URL="${FREEBSD_PACKAGE_URL}packagesite.pkg"
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:
@@ -111,19 +111,20 @@ echo "Installing required packages..."
 #env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg install mongodb openjdk unzip pcre v8 snappy
 
 fetch ${FREEBSD_PACKAGE_LIST_URL}
-tar vfx packagesite.txz
+tar vfx packagesite.pkg
 
 AddPkg () {
  	pkgname=$1
         pkg unlock -yq $pkgname
  	pkginfo=`grep "\"name\":\"$pkgname\"" packagesite.yaml`
  	pkgvers=`echo $pkginfo | pcregrep -o1 '"version":"(.*?)"' | head -1`
+	pkgurl="${FREEBSD_PACKAGE_URL}`echo $pkginfo | pcregrep -o1 '"path":"(.*?)"' | head -1`"
 
 	# compare version for update/install
  	if [ `pkg info | grep -c $pkgname-$pkgvers` -eq 1 ]; then
 	     echo "Package $pkgname-$pkgvers already installed."
 	else
-	     env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f ${FREEBSD_PACKAGE_URL}${pkgname}-${pkgvers}.txz
+	     env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f "$pkgurl"
 
 	     # if update openjdk8 then force detele snappyjava to reinstall for new version of openjdk
 	     if [ "$pkgname" == "openjdk8" ]; then


### PR DESCRIPTION
With pkg 1.17.0, `freebsd/ports/main` commit [`e497a16a286972bfcab908209b11ee6a13d99dc9`](https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9), package suffix is now .pkg. The actual package format is still an XZ-compressed tar, however - only the name has changed.

As of [`13efc89f4e4423dca7734793349bc84c843b63e3`](https://cgit.freebsd.org/ports/commit/?id=13efc89f4e4423dca7734793349bc84c843b63e3), the backwards-compatible `.txz` symlink has been dropped so our script has been broken since then.

This PR replaces every instance of `.txz` with `.pkg` and also uses a more refined method for discovering the package URL. It should resolve #287