### PR TITLE
feat: Allow controller version to be specified

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -1,11 +1,21 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # install-unifi.sh
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
-# The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/6.5.55/UniFi.unix.zip"
+# Current "known good" / "stable"
+UNIFI_VERSION="6.5.55"
 
+if [ "${1}" = "--latest" ]; then
+  LATEST_UBQ_FW_URL="$(curl -s 'https://fw-update.ubnt.com/api/firmware?filter=eq~~product~~unifi-controller&filter=eq~~platform~~unix&filter=eq~~channel~~release&sort=-version&limit=1')"
+  UNIFI_VERSION=$(echo "${LATEST_UBQ_FW_URL}" | jq '._embedded.firmware[0]._links.data.href' | jq -r 'match("(([\\d]+[.]){2}[\\d]+)").string')
+  unset LATEST_UBQ_FW_URL
+elif [ "${1}" = "--version" ] && [[ -n $(printf '"%s"' "${2}"  | jq -r 'match("(([\\d]+[.]){2}[\\d]+)").string') ]]; then
+  UNIFI_VERSION="${2}"
+fi
+
+# The latest version of UniFi:
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/${UNIFI_VERSION}/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/master/rc.d/unifi.sh"


### PR DESCRIPTION
# Description

PR implements support for passing explicit controller version to install as `major.minor.patch` version string **_OR_** pulling the latest version automatically from Ubiquiti servers by specifying `--latest`

## Examples

#### No version specified

Command:

```bash
... ~] #: install-unifi.sh
```

Result:
> Install "known good" / "stable" version - 6.5.55

#### Explicit version specified

Command:

```bash
... ~] #: install-unifi.sh --version 1.23.45
```

Result:
> Attempt to install UniFi controller version 1.23.45 (no check is made if specified version actually exists upstream, user beware)

#### Latest version specified

Command:

```bash
... ~] #: install-unifi.sh --latest
```

Result:
> Query Ubiquiti API for latest version number, install accordingly

At the time of this writing (2022-08-06), the `--latest` option currently resolves to `7.1.68`
