### PR TITLE
Add fallback packagelist URLs and mongodb versions

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -182,7 +182,9 @@ AddPkg snappy
 AddPkg cyrus-sasl
 AddPkg icu
 AddPkg boost-libs
-AddPkg ${CURRENT_MONGODB_VERSION}
+if [ ! -z "$CURRENT_MONGODB_VERSION" ]; then
+  AddPkg ${CURRENT_MONGODB_VERSION}
+fi
 AddPkg unzip
 AddPkg pcre
 


### PR DESCRIPTION
This PR adds the ability to try multiple URLs for grabbing the packagelist. It also adds support for multiple mongodb packages and installs the latest version available on the remote repository. Should resolve #305 