### PR TITLE
beta UniFi Network Application 7.5.187 Freebsd13

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -11,7 +11,7 @@ RC_SCRIPT_URL="https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/
 
 # List of valid/supported mongodb package names, sorted with the latest being first
 # As UniFi adds support for new mongodb versions, just prepend them to this list
-SUPPORTED_MONGODB_PACKAGES="mongodb50 mongodb44 mongodb42 mongodb40 mongodb36 mongodb34 mongodb32 mongodb"
+SUPPORTED_MONGODB_PACKAGES="mongodb44 mongodb42 mongodb40 mongodb36 mongodb34 mongodb32 mongodb"
 
 # If pkg-ng is not yet installed, bootstrap it:
 if ! /usr/sbin/pkg -N 2> /dev/null; then
@@ -157,7 +157,7 @@ AddPkg freetype2
 AddPkg fontconfig
 AddPkg alsa-lib
 AddPkg mpdecimal
-AddPkg python38
+AddPkg python39
 AddPkg libfontenc
 AddPkg mkfontscale
 AddPkg dejavu

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.5.174-e258d1dd8c/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.5.187-f57f5bf7ab/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/master/rc.d/unifi.sh"

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.5.172-39991973d0/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.5.174-e258d1dd8c/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/master/rc.d/unifi.sh"

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.5.169-2ec9b4cd24/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.5.172-39991973d0/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/master/rc.d/unifi.sh"
@@ -189,7 +189,6 @@ AddPkg font-bh-ttf
 AddPkg font-misc-ethiopic
 AddPkg font-misc-meltho
 AddPkg xorg-fonts-truetype
-AddPkg openjdk11
 AddPkg graphite2
 AddPkg harfbuzz
 AddPkg openjdk17
@@ -200,11 +199,7 @@ AddPkg boost-libs
 AddPkg libunwind
 AddPkg snowballstemmer
 AddPkg yaml-cpp
-if [ -n "$FALLBACK_MONGO_PACKAGE_URL" ]; then
-	AddPkg ${CURRENT_MONGODB_VERSION} ${FALLBACK_MONGO_PACKAGE_URL}
-else
-	AddPkg ${CURRENT_MONGODB_VERSION}
-fi
+AddPkg ${CURRENT_MONGODB_VERSION}
 AddPkg unzip
 AddPkg pcre
 


### PR DESCRIPTION
beta UniFi Network Application 7.5.187
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-7-5-187/e6faa0fa-ebf2-497e-9e42-901a1840d206)
Install command: fetch -o - https://tinyurl.com/44v7wa2n | sh -s
Other changes: saw some posted this fix for the log errors in the main Unifi forums page...
by User "doestergaard"
[view post](https://community.ui.com/releases/UniFi-Network-Application-7-5-174/d05b091f-f00c-4ebb-8f42-b77e0adac78b?page=2)
```
/usr/local/etc/rc.d/unifi.sh
Try appending --add-opens=java.base/java.time=ALL-UNNAMED to your execstart:
ExecStart=/usr/bin/java --add-opens=java.base/java.time=ALL-UNNAMED -jar /opt/UniFi/lib/ace.jar 
```
using winscp I modified 
```
    # So we start it in the background and stash the pid:
    /usr/local/bin/java -jar /usr/local/UniFi/lib/ace.jar start &
```
 to
```
    # So we start it in the background and stash the pid:
    /usr/local/bin/java --add-opens=java.base/java.time=ALL-UNNAMED -jar /usr/local/UniFi/lib/ace.jar start &
```




beta UniFi Network Application 7.5.174
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-7-5-165/9b957451-acc0-4a80-92e7-affdf00612bb)
Install command: fetch -o - https://tinyurl.com/2p8hy9z7 | sh -s

beta UniFi Network Application 7.5.172
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-7-5-165/9b957451-acc0-4a80-92e7-affdf00612bb)
Install command: fetch -o - https://tinyurl.com/2hwtd9kk | sh -s

beta UniFi Network Application 7.5.165
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-7-5-165/9b957451-acc0-4a80-92e7-affdf00612bb)
Install command: fetch -o - https://tinyurl.com/298av2mx | sh -s

AddPkg graphite2
AddPkg harfbuzz
AddPkg openjdk17
Updated MongoDB44