### PR TITLE
beta UniFi Network Application 9.5.21

### DIFF
--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -201,7 +201,9 @@ AddPkg boost-libs
 AddPkg libunwind
 AddPkg snowballstemmer
 AddPkg yaml-cpp
-AddPkg ${CURRENT_MONGODB_VERSION}
+if [ ! -z "$CURRENT_MONGODB_VERSION" ]; then
+  AddPkg ${CURRENT_MONGODB_VERSION}
+fi
 AddPkg unzip
 AddPkg pcre
 

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/9.2.79-oc34psn1p2/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/9.5.15-8y331i8j8s/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -4,7 +4,7 @@
 # Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/9.5.15-8y331i8j8s/UniFi.unix.zip"
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/9.5.21-6nxxr6v29z/UniFi.unix.zip"
 
 
 # The rc script associated with this branch or fork:


### PR DESCRIPTION
beta UniFi Network Application 9.5.21
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-9-5-21/e36f8a25-0d05-4cd2-b21b-6affd4aba5a5)
Install command: fetch -o - https://tinyurl.com/4f73tuyf | sh -s
TESTED ON Versions: OPNsense 25.7.5-amd64; FreeBSD 14.3-RELEASE-p2; OpenSSL 3.0.17


beta UniFi Network Application 9.5.15
[Firmware Overview/Details](https://community.ui.com/releases/UniFi-Network-Application-9-5-15/56a9c43c-8d8b-47a5-b972-2491eb505d7c)
Install command: fetch -o - https://tinyurl.com/4n93j59m | sh -s
TESTED ON Versions: OPNsense 25.7.3_7-amd64; FreeBSD 14.3-RELEASE-p2; OpenSSL 3.0.17
