### PR TITLE
feat: upgraded unifi, mongodb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## [Unreleased] - 2026-02-10
+
+### Breaking Changes
+- **Minimum FreeBSD version raised to 15.0+** (pfSense 2.8.1+). The script now exits with an error on older systems.
+- **OpenJDK 8 replaced with OpenJDK 17**. UniFi 7.5+ requires JDK 17.
+- **MongoDB 4.2 replaced with MongoDB 7.0**. Users upgrading from MongoDB 4.2 must step through intermediate versions (4.2 -> 4.4 -> 5.0 -> 6.0 -> 7.0) or perform a fresh install with backup restore.
+- Removed `snappyjava` package and snappy-java replacement logic (not needed with JDK 17 + modern UniFi).
+- Removed `python37` and `mpdecimal` packages (no longer dependencies).
+- Removed `--smallfiles` MongoDB option (deprecated in 4.2+, removed in 5.0+).
+
+### Added
+- **External MongoDB support** via environment variables (`MONGO_EXTERNAL`, `MONGO_URI`, `MONGO_STAT_URI`, `MONGO_DB_NAME`). Allows using a remote MongoDB instance instead of local.
+- FreeBSD version gate — script validates FreeBSD 15.0+ before proceeding.
+- New OpenJDK 17 dependencies: `harfbuzz`, `lcms2`, `jpeg-turbo`, `libXrandr`, `gcc14`.
+- Expanded old MongoDB cleanup — removes versions 3.6 through 6.0.
+- Cleanup of old Java versions (`openjdk8`, `openjdk11`) during installation.
+- MongoDB repair now conditional — only runs for local MongoDB when data directory exists.
+- MongoDB package installation conditional — skipped when using external MongoDB.
+
+### Changed
+- UniFi Controller updated from 7.2.97 to **10.1.84**.
+- MongoDB updated from `mongodb42` to `mongodb70`.
+- Java updated from `openjdk8` to `openjdk17`.
+- Fixed bashism: `==` comparison changed to `=` for POSIX sh compliance.
+- Updated README with new version references, external MongoDB documentation, and migration warnings.
+- Updated Usage section with direct raw GitHub URL (replaced tinyurl).
+- Updated troubleshooting section for OpenJDK 17.
+
+### Removed
+- Support for FreeBSD < 15.0 / pfSense < 2.8.1.
+- `snappyjava` package and snappy-java JAR replacement logic.
+- `python37` and `mpdecimal` packages.
+- `--smallfiles` MongoDB configuration for small partitions.
+- Old MongoDB 3.6 to 4.2 upgrade instructions from README (replaced with 4.2 to 7.0 migration warning).

--- a/README.md
+++ b/README.md
@@ -15,15 +15,20 @@ Status
 
 The project provides an rc script to start and stop the UniFi controller, and an installation script to automatically download and install everything, including the rc script.
 
-This project uses the latest branch from Ubiquiti rather than the LTS branch. From December 2020, this means the 6.x branch.
+**Current versions:**
+- UniFi Controller: **10.1.84**
+- Java: **OpenJDK 17**
+- MongoDB: **7.0** (local default, with external MongoDB support)
 
 
 Compatibility
 -------------
 
-The script is known to work on FreeBSD-based systems, including pfSense, OPNsense, FreeNAS, and more. Be sure to check the forks for versions specific to other systems.
+**Requires FreeBSD 15.0+ / pfSense 2.8.1+**
 
-This script *will destroy* a legacy BIOS system booting from an MBR formatted ZFS root volume; see [#168](https://github.com/unofficial-unifi/unifi-pfsense/issues/168). Again, using this script on a system with an MBR formatted ZFS root volume will break your system. It appears that one of the dependency packages may cause this. We have not isolated which. To avoid this problem, use UEFI mode if available, use GPT partitions, or use a filesystem other than ZFS. If you have already set up your system to use legacy BIOS, MBR partitons, and ZFS, then *do not run this script.*
+This script targets modern FreeBSD 15-based systems. Older versions of pfSense (2.7.x and earlier) and FreeBSD (14.x and earlier) are **not supported** by this version of the script.
+
+This script *will destroy* a legacy BIOS system booting from an MBR formatted ZFS root volume; see [#168](https://github.com/unofficial-unifi/unifi-pfsense/issues/168). Again, using this script on a system with an MBR formatted ZFS root volume will break your system. It appears that one of the dependency packages may cause this. We have not isolated which. To avoid this problem, use UEFI mode if available, use GPT partitions, or use a filesystem other than ZFS. If you have already set up your system to use legacy BIOS, MBR partitions, and ZFS, then *do not run this script.*
 
 
 Challenges
@@ -63,12 +68,30 @@ To install the controller software and the rc script:
 2. Run this one-line command, which downloads the install script from Github and executes it with sh:
 
   ```
-    fetch -o - https://tinyurl.com/3ukj9253 | sh -s
+    fetch -o - https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/master/install-unifi/install-unifi.sh | sh -s
   ```
 
 The install script will install dependencies, download the UniFi controller software, make some adjustments, and start the UniFi controller.
 
-The git.io link above should point to `https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/master/install-unifi/install-unifi.sh`
+### External MongoDB
+
+You can use an external MongoDB instance instead of the local one bundled with the installation. Set the following environment variables before running the install script:
+
+  ```
+    env MONGO_EXTERNAL=true \
+        MONGO_URI="mongodb://user:pass@mongo-host:27017/unifi" \
+        MONGO_STAT_URI="mongodb://user:pass@mongo-host:27017/unifi_stat" \
+        MONGO_DB_NAME="unifi" \
+        sh install-unifi.sh
+  ```
+
+When using external MongoDB:
+- MongoDB packages are not installed locally
+- MongoDB repair step is skipped
+- The mongod symlink is not created
+- Connection details are written to `/usr/local/UniFi/data/system.properties`
+
+**Note:** The external MongoDB instance must be MongoDB 7.0 or later for compatibility with UniFi 10.x.
 
 
 Starting and Stopping
@@ -94,19 +117,19 @@ To start and stop the controller, use the `service` command from the command lin
 After Installing
 ----------------
 
-After using this script to install the UniFi Controller software, check the [UniFi controller documentation](https://help.ui.com/hc/en-us/articles/360012282453-UniFi-Set-up-a-UniFi-Network-Controller#h_52fdb29d-86cc-4f07-8f09-bd6b7268b525) for next steps. 
+After using this script to install the UniFi Controller software, check the [UniFi controller documentation](https://help.ui.com/hc/en-us/articles/360012282453-UniFi-Set-up-a-UniFi-Network-Controller#h_52fdb29d-86cc-4f07-8f09-bd6b7268b525) for next steps.
 
 
 Troubleshooting
 ---------------
 
-Step one is to determine whether the issue you’ve encountered is with this script or with the UniFi controller software. 
+Step one is to determine whether the issue you've encountered is with this script or with the UniFi controller software.
 
 Issues with the script  might include problems downloading packages, installing packages, interactions with pfSense such as dependency packages being deleted after updates, or incorrect dependencies being downloaded. Feel free to open an issue for anything like this.
 
 Issues with the UniFi Controller software or its various dependencies might include not starting up, not listening on port 8443, exiting with a port conflict, crashing after startup, database errors, memory issues, file permissions, dependency conflicts, or the weather. You should troubleshoot these issues as you would on any other installation of UniFi Controller. For some, the first stop is UniFi technical support; for others, ready answers to most questions about setting up UniFi controller are found most quickly on the UniFi forums.
 
-It may turn out that some issue with the UniFi Controller software is caused by something this script is doing, like if MongoDB won’t start because you’re running it on a PDP-8 with 12-bit words, and this script is installing the build of MongoDB for PDP-11 systems with 16-bit words. In a case like that, if you can connect the behavior of the UniFi Controller with the actions taken by the script, please open an issue, or, better yet, fork and fix and submit a PR.
+It may turn out that some issue with the UniFi Controller software is caused by something this script is doing. In a case like that, if you can connect the behavior of the UniFi Controller with the actions taken by the script, please open an issue, or, better yet, fork and fix and submit a PR.
 
 ### Java compatibility on FreeBSD
 
@@ -115,42 +138,31 @@ This script may create a conflict that breaks Java on a FreeBSD upgrade. To reso
   ```
 pkg unlock -yq javavmwrapper
 pkg unlock -yq java-zoneinfo
-pkg unlock -yq openjdk8
-pkg unlock -yq snappyjava
-pkg unlock -yq snappy
-pkg unlock -yq mongodb36
+pkg unlock -yq openjdk17
 pkg remove -y javavmwrapper
 pkg remove -y java-zoneinfo
   ```
 
-### Compatibility upgrade to MONGODB 4.2 (for those using MongoDB 4.2 or having DB compatibility problems)
+### MongoDB migration warning
 
-The following is a workaround for upgrading MongoDB 3.6 to MonggoDB 4.2 to resolve conflict and crashes in Unifi Controller related to MongoDB versions.
-contributed by user ccottam and johnkeates.
+**If you are upgrading from an older version of this script that used MongoDB 4.2 or earlier**, you cannot jump directly to MongoDB 7.0. MongoDB requires stepping through each major version's feature compatibility level:
 
-1. Install the May 30 version first (https://github.com/unofficial-unifi/unifi-pfsense/blob/e51c3a6f9b55080d1e9b6100a8d42daa30641ba9/install-unifi/install-unifi.sh) to get a working mongo 3.6 database and make sure everything still works.
-(if you are unable to install this, try going directly to step 2)
+**4.2 -> 4.4 -> 5.0 -> 6.0 -> 7.0**
 
-2. Install a mongo 4.0 version: (Jun 1) https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/4167b09685d1bdf881d9076ba01d8ff2ab173a81/install-unifi/install-unifi.sh
-
-3. Set the feature version to 4.0:
-having installed mongodb 4.0, run the following command in shell to set compatibility feature
-
+For each step:
+1. Install the next MongoDB version
+2. Connect to MongoDB and set the feature compatibility version:
   ```
-cmd> mongo localhost:27117
+mongo localhost:27117
+db.adminCommand( { setFeatureCompatibilityVersion: "<version>" } )
   ```
+3. Verify with:
   ```
-cmd> db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )
-response> { "featureCompatibilityVersion" : { "version" : "3.6" }, "ok" : 1 }
-cmd>  db.adminCommand( { setFeatureCompatibilityVersion: "4.0" } )
-response> { "ok" : 1 }
-cmd> db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )
-response> { "featureCompatibilityVersion" : { "version" : "4.0" }, "ok" : 1 }
+db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )
   ```
-4. Install the newer Jun 1 version next (upgrades to 4.2) (https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/c04a44f34f7c9c7c4e358d43dd7d74b1e676ef6a/install-unifi/install-unifi.sh)
-At this point you have a mongodb that was upgraded from 3.6 to 4.0, the database itself has been upgraded to be 4.0 compatible, finally mongodb 4.2 has been installed. Any database repairs will be handled automatically by the installation script.
+4. Then proceed to the next version
 
-5. Install the latest version of Unifi Controller
+**Alternatively**, you can export your UniFi backup from the old controller, perform a fresh install with this script (which installs MongoDB 7.0), and then restore your backup through the UniFi web interface.
 
 
 Uninstalling
@@ -192,7 +204,7 @@ If you're aware of an update before I am:
 
 1. Create a branch from master, named for the version you are about to test.
 2. Update the URL in install.sh to the latest version.
-3. Test it on your pfSense system.
+3. Test it on your pfSense 2.8.1+ system.
 4. Optional, but ideal: test it on a fresh pfSense system, as in a VM.
 5. If it checks out, submit a pull request from your branch. This helps bring my attention to the update and lets me know that you have tested the new version.
 

--- a/install-unifi/install-unifi.sh
+++ b/install-unifi/install-unifi.sh
@@ -1,16 +1,22 @@
 #!/bin/sh
 
 # install-unifi.sh
-# Installs the Uni-Fi controller software on a FreeBSD machine (presumably running pfSense).
+# Installs the UniFi Controller software on a FreeBSD machine (presumably running pfSense).
+# Requires FreeBSD 15.0+ / pfSense 2.8.1+
 
 # The latest version of UniFi:
-UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/7.2.97/UniFi.unix.zip"
-
+UNIFI_SOFTWARE_URL="https://dl.ui.com/unifi/10.1.84/UniFi.unix.zip"
 
 # The rc script associated with this branch or fork:
 RC_SCRIPT_URL="https://raw.githubusercontent.com/unofficial-unifi/unifi-pfsense/master/rc.d/unifi.sh"
 
-CURRENT_MONGODB_VERSION=mongodb42
+CURRENT_MONGODB_VERSION=mongodb70
+
+# External MongoDB support (set these env vars before running to use external MongoDB)
+MONGO_EXTERNAL=${MONGO_EXTERNAL:-false}
+MONGO_URI=${MONGO_URI:-}
+MONGO_STAT_URI=${MONGO_STAT_URI:-}
+MONGO_DB_NAME=${MONGO_DB_NAME:-unifi}
 
 # If pkg-ng is not yet installed, bootstrap it:
 if ! /usr/sbin/pkg -N 2> /dev/null; then
@@ -25,14 +31,37 @@ if ! /usr/sbin/pkg -N 2> /dev/null; then
   exit 1
 fi
 
+# Require FreeBSD 15.0 or later:
+OSVERSION=$(uname -U)
+if [ "${OSVERSION}" -lt 1500000 ]; then
+  echo "ERROR: This script requires FreeBSD 15.0 or later. Detected: $(uname -r)"
+  exit 1
+fi
+
 # Determine this installation's Application Binary Interface
-ABI=`/usr/sbin/pkg config abi`
+ABI=$(/usr/sbin/pkg config abi)
 
-# FreeBSD package source:
-FREEBSD_PACKAGE_URL="https://pkg.freebsd.org/${ABI}/latest/"
+# Configure FreeBSD package repository for dependency resolution
+FREEBSD_REPO_URL="https://pkg.freebsd.org/${ABI}/latest"
+FREEBSD_REPO_CONF="/usr/local/etc/pkg/repos/FreeBSD-unifi.conf"
 
-# FreeBSD package list:
-FREEBSD_PACKAGE_LIST_URL="${FREEBSD_PACKAGE_URL}packagesite.pkg"
+mkdir -p /usr/local/etc/pkg/repos
+cat > "${FREEBSD_REPO_CONF}" <<REPOEOF
+FreeBSD-unifi: {
+  url: "${FREEBSD_REPO_URL}",
+  enabled: yes,
+  mirror_type: "none"
+}
+REPOEOF
+
+# Lock pkg to prevent it from being upgraded (pfSense's pkg is built against
+# pfSense's base libraries; the FreeBSD upstream pkg will break)
+pkg lock -yq pkg 2>/dev/null
+
+# Update the package catalog from the FreeBSD repo
+echo "Updating package catalog..."
+env ASSUME_ALWAYS_YES=YES IGNORE_OSVERSION=yes /usr/sbin/pkg update -f -r FreeBSD-unifi
+echo " done."
 
 # Stop the controller if it's already running...
 # First let's try the rc script if it exists:
@@ -45,37 +74,39 @@ fi
 # Then to be doubly sure, let's make sure ace.jar isn't running for some other reason:
 if [ $(ps ax | grep -c "/usr/local/UniFi/lib/[a]ce.jar start") -ne 0 ]; then
   echo -n "Killing ace.jar process..."
-  /bin/kill -15 `ps ax | grep "/usr/local/UniFi/lib/[a]ce.jar start" | awk '{ print $1 }'`
+  /bin/kill -15 $(ps ax | grep "/usr/local/UniFi/lib/[a]ce.jar start" | awk '{ print $1 }')
   echo " done."
 fi
 
 # And then make sure mongodb doesn't have the db file open:
 if [ $(ps ax | grep -c "/usr/local/UniFi/data/[d]b") -ne 0 ]; then
   echo -n "Killing mongod process..."
-  /bin/kill -15 `ps ax | grep "/usr/local/UniFi/data/[d]b" | awk '{ print $1 }'`
+  /bin/kill -15 $(ps ax | grep "/usr/local/UniFi/data/[d]b" | awk '{ print $1 }')
   echo " done."
 fi
 
-# Repairs Mongodb database in case of corruption
-mongod --dbpath /usr/local/UniFi/data/db --repair
+# Repairs MongoDB database in case of corruption (only for local MongoDB)
+if [ "${MONGO_EXTERNAL}" != "true" ] && [ -d /usr/local/UniFi/data/db ]; then
+  mongod --dbpath /usr/local/UniFi/data/db --repair
+fi
 
 # If an installation exists, we'll need to back up configuration:
 if [ -d /usr/local/UniFi/data ]; then
   echo "Backing up UniFi data..."
-  BACKUPFILE=/var/backups/unifi-`date +"%Y%m%d_%H%M%S"`.tgz
-  /usr/bin/tar -vczf ${BACKUPFILE} /usr/local/UniFi/data
+  BACKUPFILE=/var/backups/unifi-$(date +"%Y%m%d_%H%M%S").tgz
+  /usr/bin/tar -vczf "${BACKUPFILE}" /usr/local/UniFi/data
 fi
 
-# Add the fstab entries apparently required for OpenJDKse:
+# Add the fstab entries apparently required for OpenJDK:
 if [ $(grep -c fdesc /etc/fstab) -eq 0 ]; then
   echo -n "Adding fdesc filesystem to /etc/fstab..."
-  echo -e "fdesc\t\t\t/dev/fd\t\tfdescfs\trw\t\t0\t0" >> /etc/fstab
+  printf "fdesc\t\t\t/dev/fd\t\tfdescfs\trw\t\t0\t0\n" >> /etc/fstab
   echo " done."
 fi
 
 if [ $(grep -c proc /etc/fstab) -eq 0 ]; then
   echo -n "Adding procfs filesystem to /etc/fstab..."
-  echo -e "proc\t\t\t/proc\t\tprocfs\trw\t\t0\t0" >> /etc/fstab
+  printf "proc\t\t\t/proc\t\tprocfs\trw\t\t0\t0\n" >> /etc/fstab
   echo " done."
 fi
 
@@ -84,94 +115,64 @@ echo -n "Mounting new filesystems..."
 /sbin/mount -a
 echo " done."
 
+# Unlock all previously locked packages to avoid conflicts
+pkg unlock -ayq 2>/dev/null
 
+# Remove all old MongoDB versions
 echo "Removing discontinued packages..."
-old_mongos=`pkg info | grep mongodb | grep -v ${CURRENT_MONGODB_VERSION}`
-for old_mongo in "${old_mongos}"; do
-  package=`echo "$old_mongo" | cut -d' ' -f1`
-  pkg unlock -yq ${package}
-  env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete ${package}
+for old_ver in mongodb36 mongodb40 mongodb42 mongodb44 mongodb50 mongodb60; do
+  if pkg info -e ${old_ver} 2>/dev/null; then
+    env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete ${old_ver}
+  fi
+done
+
+# Remove old Java versions
+for old_java in openjdk8 openjdk11; do
+  if pkg info -e ${old_java} 2>/dev/null; then
+    env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete ${old_java}
+  fi
+done
+
+# Remove packages no longer needed
+for old_pkg in python37 mpdecimal snappyjava; do
+  if pkg info -e ${old_pkg} 2>/dev/null; then
+    env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete ${old_pkg}
+  fi
 done
 echo " done."
 
-
-
-# Install mongodb, OpenJDK, and unzip (required to unpack Ubiquiti's download):
-# -F skips a package if it's already installed, without throwing an error.
+# Install packages using pkg install (auto-resolves all dependencies)
 echo "Installing required packages..."
-#uncomment below for pfSense 2.2.x:
-#env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg install mongodb openjdk unzip pcre v8 snappy
 
-fetch ${FREEBSD_PACKAGE_LIST_URL}
-tar vfx packagesite.pkg
+# Install OpenJDK 17 and all its dependencies
+env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg install -r FreeBSD-unifi -f \
+  openjdk17 \
+  javavmwrapper \
+  java-zoneinfo \
+  libinotify \
+  unzip \
+  || exit 1
 
-AddPkg () {
-  pkgname=$1
-  pkg unlock -yq $pkgname
-  pkginfo=`grep "\"name\":\"$pkgname\"" packagesite.yaml`
-  pkgvers=`echo $pkginfo | pcregrep -o1 '"version":"(.*?)"' | head -1`
-  pkgurl="${FREEBSD_PACKAGE_URL}`echo $pkginfo | pcregrep -o1 '"path":"(.*?)"' | head -1`"
+# Install MongoDB (only if using local MongoDB)
+if [ "${MONGO_EXTERNAL}" != "true" ]; then
+  env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg install -r FreeBSD-unifi -f \
+    ${CURRENT_MONGODB_VERSION} \
+    || exit 1
+fi
 
-  # compare version for update/install
-  if [ `pkg info | grep -c $pkgname-$pkgvers` -eq 1 ]; then
-    echo "Package $pkgname-$pkgvers already installed."
-  else
-    env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg add -f "$pkgurl" || exit 1
+# Lock installed packages to prevent pfSense from removing them during updates
+for pkg_to_lock in openjdk17 javavmwrapper java-zoneinfo libinotify unzip; do
+  pkg lock -yq ${pkg_to_lock} 2>/dev/null
+done
 
-    # if update openjdk8 then force detele snappyjava to reinstall for new version of openjdk
-    if [ "$pkgname" == "openjdk8" ]; then
-      pkg unlock -yq snappyjava
-      env ASSUME_ALWAYS_YES=YES /usr/sbin/pkg delete snappyjava
-    fi
-  fi
-  pkg lock -yq $pkgname
-}
-
-#Add the following Packages for installation or reinstallation (if something was removed)
-AddPkg png
-AddPkg brotli
-AddPkg freetype2
-AddPkg fontconfig
-AddPkg alsa-lib
-AddPkg mpdecimal
-AddPkg python37
-AddPkg libfontenc
-AddPkg mkfontscale
-AddPkg dejavu
-AddPkg giflib
-AddPkg xorgproto
-AddPkg libXdmcp
-AddPkg libXau
-AddPkg libxcb
-AddPkg libICE
-AddPkg libSM
-AddPkg libX11
-AddPkg libXfixes
-AddPkg libXext
-AddPkg libXi
-AddPkg libXt
-AddPkg libXtst
-AddPkg libXrender
-AddPkg libinotify
-AddPkg javavmwrapper
-AddPkg java-zoneinfo
-AddPkg openjdk8
-AddPkg snappyjava
-AddPkg snappy
-AddPkg cyrus-sasl
-AddPkg icu
-AddPkg boost-libs
-AddPkg ${CURRENT_MONGODB_VERSION}
-AddPkg unzip
-AddPkg pcre
-
-# Clean up downloaded package manifest:
-rm packagesite.*
+if [ "${MONGO_EXTERNAL}" != "true" ]; then
+  pkg lock -yq ${CURRENT_MONGODB_VERSION} 2>/dev/null
+fi
 
 echo " done."
 
-# Switch to a temp directory for the Unifi download:
-cd `mktemp -d -t unifi`
+# Switch to a temp directory for the UniFi download:
+cd $(mktemp -d -t unifi) || exit 1
 
 # Download the controller from Ubiquiti (assuming acceptance of the EULA):
 echo -n "Downloading the UniFi controller software..."
@@ -184,30 +185,31 @@ echo -n "Installing UniFi controller in /usr/local..."
 /usr/local/bin/unzip -o UniFi.unix.zip -d /usr/local
 echo " done."
 
-# Update Unifi's symbolic link for mongod to point to the version we just installed:
-echo -n "Updating mongod link..."
-/bin/ln -sf /usr/local/bin/mongod /usr/local/UniFi/bin/mongod
-echo " done."
-
-# If partition size is < 4GB, add smallfiles option to mongodb
-echo -n "Checking partition size..."
-if [ `df -k | awk '$NF=="/"{print $2}'` -le 4194302 ]; then
-  echo -e "\nunifi.db.extraargs=--smallfiles\n" >> /usr/local/UniFi/data/system.properties
-fi
-echo " done."
-
-# Replace snappy java library to support AP adoption with latest firmware:
-echo -n "Updating snappy java..."
-unifizipcontents=`zipinfo -1 UniFi.unix.zip`
-upstreamsnappyjavapattern='/(snappy-java-[^/]+\.jar)$'
-# Make sure exactly one match is found
-if [ $(echo "${unifizipcontents}" | egrep -c ${upstreamsnappyjavapattern}) -eq 1 ]; then
-  upstreamsnappyjava="/usr/local/UniFi/lib/`echo \"${unifizipcontents}\" | pcregrep -o1 ${upstreamsnappyjavapattern}`"
-  mv "${upstreamsnappyjava}" "${upstreamsnappyjava}.backup"
-  cp /usr/local/share/java/classes/snappy-java.jar "${upstreamsnappyjava}"
+# Update UniFi's symbolic link for mongod to point to the version we just installed
+# (only if using local MongoDB):
+if [ "${MONGO_EXTERNAL}" != "true" ]; then
+  echo -n "Updating mongod link..."
+  /bin/ln -sf /usr/local/bin/mongod /usr/local/UniFi/bin/mongod
   echo " done."
-else
-  echo "ERROR: Could not locate UniFi's snappy java! AP adoption will most likely fail"
+fi
+
+# Configure external MongoDB if requested:
+if [ "${MONGO_EXTERNAL}" = "true" ] && [ -n "${MONGO_URI}" ]; then
+  echo "Configuring external MongoDB..."
+  mkdir -p /usr/local/UniFi/data
+  # Remove existing mongo config lines if present
+  if [ -f /usr/local/UniFi/data/system.properties ]; then
+    grep -v '^db\.mongo\.\|^statdb\.mongo\.\|^unifi\.db\.name' \
+      /usr/local/UniFi/data/system.properties > /usr/local/UniFi/data/system.properties.tmp
+    mv /usr/local/UniFi/data/system.properties.tmp /usr/local/UniFi/data/system.properties
+  fi
+  cat >> /usr/local/UniFi/data/system.properties <<MONGOEOF
+db.mongo.local=false
+db.mongo.uri=${MONGO_URI}
+statdb.mongo.uri=${MONGO_STAT_URI:-${MONGO_URI}_stat}
+unifi.db.name=${MONGO_DB_NAME}
+MONGOEOF
+  echo " done."
 fi
 
 # Fetch the rc script from github:
@@ -228,11 +230,14 @@ if [ ! -f /etc/rc.conf.local ] || [ $(grep -c unifi_enable /etc/rc.conf.local) -
 fi
 
 # Restore the backup:
-if [ ! -z "${BACKUPFILE}" ] && [ -f ${BACKUPFILE} ]; then
+if [ -n "${BACKUPFILE}" ] && [ -f "${BACKUPFILE}" ]; then
   echo "Restoring UniFi data..."
-  mv /usr/local/UniFi/data /usr/local/UniFi/data-`date +%Y%m%d-%H%M`
-  /usr/bin/tar -vxzf ${BACKUPFILE} -C /
+  mv /usr/local/UniFi/data "/usr/local/UniFi/data-$(date +%Y%m%d-%H%M)"
+  /usr/bin/tar -vxzf "${BACKUPFILE}" -C /
 fi
+
+# Clean up the temporary repo config
+rm -f "${FREEBSD_REPO_CONF}"
 
 # Start it up:
 echo -n "Starting the unifi service..."


### PR DESCRIPTION
<p dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Note: I already have the changes ready in my local branch and working on the stack below. I'm running with MongoDB Atlas as the database.<br style="box-sizing: border-box;">If you want the updated script, give me access to create a branch and I'll provide it to you.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The current script is incompatible with pfSense 2.8.1 (FreeBSD 15.0). This issue tracks the changes needed to support the modern stack.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Current State (broken)</h2><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding-left: 2em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box;">UniFi 7.2.97 — EOL, no longer supported</li><li style="box-sizing: border-box; margin-top: 0.25em;">OpenJDK 8 — not available on FreeBSD 15</li><li style="box-sizing: border-box; margin-top: 0.25em;">MongoDB 4.2 — EOL, not available on FreeBSD 15</li><li style="box-sizing: border-box; margin-top: 0.25em;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pcregrep</code><span> </span>used in<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">AddPkg</code><span> </span>— not present on pfSense 2.8.1 base</li><li style="box-sizing: border-box; margin-top: 0.25em;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg add</code><span> </span>doesn't resolve transitive dependencies — fails on OpenJDK 17's deep dependency tree</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Required Changes</h2><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Version bumps</h3><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Component | Current | Required
-- | -- | --
UniFi | 7.2.97 | 10.1.84
Java | openjdk8 | openjdk17
MongoDB | mongodb42 | mongodb70
Target OS | FreeBSD 10+ | FreeBSD 15.0+ / pfSense 2.8.1+

</markdown-accessiblity-table><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Package installation approach</h3><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">AddPkg</code><span> </span>function uses<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pcregrep</code><span> </span>(not in pfSense 2.8.1 base) and<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg add</code><span> </span>(doesn't resolve dependencies). On pfSense 2.8.1, this should be replaced with:</p><ol dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding-left: 2em; list-style-type: decimal; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box;">Configure a temporary FreeBSD package repo (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg.freebsd.org</code>)</li><li style="box-sizing: border-box; margin-top: 0.25em;"><strong style="box-sizing: border-box; font-weight: 600;">Lock<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg</code><span> </span>before installing</strong><span> </span>— pfSense's<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg</code><span> </span>is built against pfSense's base libraries (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">libutil.so.9</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">libssl.so.30</code>), while FreeBSD upstream<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg</code><span> </span>expects<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.10</code><span> </span>and<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.35</code>.<br style="box-sizing: border-box;">If<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg</code><span> </span>upgrades itself, it breaks completely and requires<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg-static bootstrap -f</code><span> </span>to recover.</li><li style="box-sizing: border-box; margin-top: 0.25em;">Use<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg install -r &lt;repo&gt;</code><span> </span>which resolves all transitive dependencies automatically</li><li style="box-sizing: border-box; margin-top: 0.25em;">Lock installed packages after installation</li><li style="box-sizing: border-box; margin-top: 0.25em;">Clean up the temporary repo config</li></ol><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Deprecated logic to remove</h3><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding-left: 2em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--smallfiles</code><span> </span>MongoDB option (removed in MongoDB 5.0+)</li><li style="box-sizing: border-box; margin-top: 0.25em;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">snappyjava</code><span> </span>replacement logic (not needed with JDK 17 + modern UniFi)</li><li style="box-sizing: border-box; margin-top: 0.25em;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">python37</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">mpdecimal</code><span> </span>packages (not dependencies of openjdk17/mongodb70)</li><li style="box-sizing: border-box; margin-top: 0.25em;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">==</code><span> </span>bashism in<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">AddPkg</code><span> </span>(POSIX sh requires<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">=</code>)</li></ul><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New features</h3><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding-left: 2em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box;"><strong style="box-sizing: border-box; font-weight: 600;">External MongoDB support</strong><span> </span>via env vars (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">MONGO_EXTERNAL</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">MONGO_URI</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">MONGO_STAT_URI</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">MONGO_DB_NAME</code>) — useful for offloading to MongoDB Atlas</li><li style="box-sizing: border-box; margin-top: 0.25em;">FreeBSD version gate (exit early on &lt; 15.0)</li><li style="box-sizing: border-box; margin-top: 0.25em;">Cleanup of old MongoDB versions (3.6 through 6.0) and old Java (openjdk8, openjdk11)</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tested on</h2><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding-left: 2em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box;">pfSense 2.8.1-RELEASE (FreeBSD 15.0-CURRENT,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">uname -U</code><span> </span>= 1500029)</li><li style="box-sizing: border-box; margin-top: 0.25em;">Intel Celeron J4105, 8GB RAM</li><li style="box-sizing: border-box; margin-top: 0.25em;">MongoDB Atlas (external) with<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">mongodb+srv://</code><span> </span>connection strings</li><li style="box-sizing: border-box; margin-top: 0.25em;">UniFi 10.1.84 successfully running on port 8443</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Key gotcha for contributors</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">pfSense 2.8.1's base system differs from stock FreeBSD 15:</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding-left: 2em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">libutil.so.9</code><span> </span>(FreeBSD upstream has<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.10</code>)</li><li style="box-sizing: border-box; margin-top: 0.25em;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">libssl.so.30</code><span> </span>(FreeBSD upstream has<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.35</code>)</li></ul><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Packages from<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg.freebsd.org</code><span> </span>generally work fine, but<span> </span><strong style="box-sizing: border-box; font-weight: 600;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">pkg</code><span> </span>itself must never be upgraded</strong><span> </span>from the FreeBSD repo — it will segfault.</p>